### PR TITLE
Bump requests

### DIFF
--- a/django-network-monitor/wk18k/requirements.txt
+++ b/django-network-monitor/wk18k/requirements.txt
@@ -3,7 +3,7 @@ certifi==2023.7.22
 charset-normalizer==3.2.0
 Django==4.2.17
 idna==3.4
-requests==2.31.0
+requests==2.32.4
 sqlparse==0.4.4
 typing-extensions==4.7.1
 urllib3==2.0.4


### PR DESCRIPTION
Bumps the pip group with 1 update in the /django-network-monitor/wk18k directory: [requests](https://github.com/psf/requests).


Updates `requests` from 2.31.0 to 2.32.4
- [Release notes](https://github.com/psf/requests/releases)
- [Changelog](https://github.com/psf/requests/blob/main/HISTORY.md)
- [Commits](https://github.com/psf/requests/compare/v2.31.0...v2.32.4)

---
updated-dependencies:
- dependency-name: requests dependency-version: 2.32.4 dependency-type: direct:production dependency-group: pip ...