### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled command line

### DIFF
--- a/Linux/remote_command_excution/main.py
+++ b/Linux/remote_command_excution/main.py
@@ -12,7 +12,13 @@ logging.basicConfig(filename='rce.log', level=logging.INFO,
 USERS = {'admin': 'password123'}
 
 # List of allowed commands (whitelisting)
-ALLOWED_COMMANDS = ['ls', 'pwd', 'whoami', 'uptime']
+# Map allowed command names to actual command lists (no arguments allowed)
+ALLOWED_COMMANDS = {
+    "ls": ["ls"],
+    "pwd": ["pwd"],
+    "whoami": ["whoami"],
+    "uptime": ["uptime"]
+}
 
 # Basic HTML for the input form (simple UI)
 html_page = """
@@ -59,8 +65,8 @@ def execute_command(command):
         return "Command not allowed", 400
 
     try:
-        # Execute the command securely without shell=True
-        output = subprocess.check_output([command], universal_newlines=True)
+        # Execute the command securely using the mapped command list (no user input passed untrusted)
+        output = subprocess.check_output(ALLOWED_COMMANDS[command], universal_newlines=True)
         # Log the successful execution
         logging.info(f"Executed command: {command}")
         return output, 200


### PR DESCRIPTION
Potential fix for [https://github.com/s3bu7i/linux-network-win-tools/security/code-scanning/6](https://github.com/s3bu7i/linux-network-win-tools/security/code-scanning/6)

To ensure user input can't be used to run arbitrary commands, the best fix is to map all allowed user-facing commands to hardcoded, trusted command-line arguments using a dictionary, and then always use the mapped value rather than the raw user input. In this snippet, instead of passing the string from the user directly, the code should use something like `COMMANDS[command]`, where `COMMANDS` is a dict mapping allowed command names to the exact commands to run.  
- Change `ALLOWED_COMMANDS` from a list to a dictionary that maps user input to the real command list, e.g., `{"ls": ["ls"], "pwd": ["pwd"], ...}`.  
- In `execute_command`, use the dictionary lookup, NOT the user input string directly, to supply the argument to `subprocess.check_output`.  
- Only the regions shown in the Linux/remote_command_excution/main.py file can be edited.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
